### PR TITLE
fix: UIView not supporting box-none ~> none

### DIFF
--- a/src/HighlightOverlay.tsx
+++ b/src/HighlightOverlay.tsx
@@ -52,7 +52,7 @@ function HighlightOverlay({ highlightedElementId, onDismiss }: HighlightOverlayP
 			{highlightedElementData != null && parentSize != null && (
 				<Svg
 					style={StyleSheet.absoluteFill}
-					pointerEvents={clickThrough ? "box-none" : "auto"}
+					pointerEvents={clickThrough ? "none" : "auto"}
 					onPress={!clickThrough ? onDismiss : undefined}
 				>
 					<G>


### PR DESCRIPTION
As mentioned in this issue but never PR'd;
https://github.com/Charanor/react-native-highlight-overlay/issues/3