### PR TITLE
Added key to HighlightOverlay svg element

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "@react-native-community/eslint-config": "^2.0.0",
     "@release-it/conventional-changelog": "^2.0.0",
     "@types/jest": "^26.0.0",
+    "@types/lodash.isequal": "^4.5.5",
     "@types/react": "^16.9.19",
     "@types/react-native": "^0.64.12",
     "@typescript-eslint/eslint-plugin": "^4.33.0",
@@ -128,6 +129,7 @@
     ]
   },
   "dependencies": {
+    "lodash.isequal": "^4.5.0",
     "react-native-svg": "^12.1.1"
   }
 }

--- a/src/HighlightOverlay.tsx
+++ b/src/HighlightOverlay.tsx
@@ -54,6 +54,7 @@ function HighlightOverlay({ highlightedElementId, onDismiss }: HighlightOverlayP
 					style={StyleSheet.absoluteFill}
 					pointerEvents={clickThrough ? "none" : "auto"}
 					onPress={!clickThrough ? onDismiss : undefined}
+					key={highlightedElementId}
 				>
 					<G>
 						<Defs>

--- a/src/context/HighlightableElementProvider.tsx
+++ b/src/context/HighlightableElementProvider.tsx
@@ -45,9 +45,8 @@ function HighlightableElementProvider({
 		(id, node, bounds, options) => {
 			if (
 				!elements[id] ||
-				node !== elements[id].node ||
 				!isEqual(bounds, elements[id].bounds) ||
-				!isEqual(options?.clickthroughHighlight, elements[id].options)
+				!isEqual(options, elements[id].options)
 			) {
 				setElements((oldElements) => ({ ...oldElements, [id]: { node, bounds, options } }));
 			}

--- a/src/context/HighlightableElementProvider.tsx
+++ b/src/context/HighlightableElementProvider.tsx
@@ -41,16 +41,19 @@ function HighlightableElementProvider({
 	);
 	const [elements, setElements] = useState<ElementsRecord>({});
 
-	const addElement = useCallback<AddElement>((id, node, bounds, options) => {
-		if (
-			!elements[id] ||
-			node !== elements[id].node ||
-			!isEqual(bounds, elements[id].bounds) ||
-			!isEqual(options?.clickthroughHighlight, elements[id].options)
-		) {
-			setElements((oldElements) => ({ ...oldElements, [id]: { node, bounds, options } }));
-		}
-	}, []);
+	const addElement = useCallback<AddElement>(
+		(id, node, bounds, options) => {
+			if (
+				!elements[id] ||
+				node !== elements[id].node ||
+				!isEqual(bounds, elements[id].bounds) ||
+				!isEqual(options?.clickthroughHighlight, elements[id].options)
+			) {
+				setElements((oldElements) => ({ ...oldElements, [id]: { node, bounds, options } }));
+			}
+		},
+		[elements]
+	);
 
 	const removeElement: RemoveElement = useCallback<RemoveElement>((id) => {
 		setElements((oldElements) => {

--- a/src/context/HighlightableElementProvider.tsx
+++ b/src/context/HighlightableElementProvider.tsx
@@ -1,6 +1,7 @@
 import type { PropsWithChildren } from "react";
 import React, { useCallback, useMemo, useState } from "react";
 import { StyleSheet, View } from "react-native";
+import isEqual from "lodash.isequal";
 
 import type { AddElement, ElementsRecord, RemoveElement } from "./context";
 import HighlightableElementContext from "./context";
@@ -13,7 +14,7 @@ export type HighlightableElementProviderProps = PropsWithChildren<{
 	 *  - The wrapper we provide is making your app look weird. This can happen when you use
 	 *    tab bars / headers / etc.
 	 *  - You have several providers for whatever reason (you probably shouldn't).
-	 * 
+	 *
 	 * @since 1.0.0
 	 */
 	rootRef?: React.Component<unknown> | null;
@@ -41,7 +42,14 @@ function HighlightableElementProvider({
 	const [elements, setElements] = useState<ElementsRecord>({});
 
 	const addElement = useCallback<AddElement>((id, node, bounds, options) => {
-		setElements((oldElements) => ({ ...oldElements, [id]: { node, bounds, options } }));
+		if (
+			!elements[id] ||
+			node !== elements[id].node ||
+			!isEqual(bounds, elements[id].bounds) ||
+			!isEqual(options?.clickthroughHighlight, elements[id].options)
+		) {
+			setElements((oldElements) => ({ ...oldElements, [id]: { node, bounds, options } }));
+		}
 	}, []);
 
 	const removeElement: RemoveElement = useCallback<RemoveElement>((id) => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1945,6 +1945,18 @@
   dependencies:
     "@types/node" "*"
 
+"@types/lodash.isequal@^4.5.5":
+  version "4.5.5"
+  resolved "https://registry.yarnpkg.com/@types/lodash.isequal/-/lodash.isequal-4.5.5.tgz#4fed1b1b00bef79e305de0352d797e9bb816c8ff"
+  integrity sha512-4IKbinG7MGP131wRfceK6W4E/Qt3qssEFLF30LnJbjYiSfHGGRU/Io8YxXrZX109ir+iDETC8hw8QsDijukUVg==
+  dependencies:
+    "@types/lodash" "*"
+
+"@types/lodash@*":
+  version "4.14.180"
+  resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.180.tgz#4ab7c9ddfc92ec4a887886483bc14c79fb380670"
+  integrity sha512-XOKXa1KIxtNXgASAnwj7cnttJxS4fksBRywK/9LzRV5YxrF80BXZIGeQSuoESQ/VkUj30Ae0+YcuHc15wJCB2g==
+
 "@types/minimist@^1.2.0":
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/@types/minimist/-/minimist-1.2.2.tgz#ee771e2ba4b3dc5b372935d549fd9617bf345b8c"
@@ -6345,6 +6357,11 @@ lodash.debounce@^4.0.8:
   version "4.0.8"
   resolved "https://registry.yarnpkg.com/lodash.debounce/-/lodash.debounce-4.0.8.tgz#82d79bff30a67c4005ffd5e2515300ad9ca4d7af"
   integrity sha1-gteb/zCmfEAF/9XiUVMArZyk168=
+
+lodash.isequal@^4.5.0:
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/lodash.isequal/-/lodash.isequal-4.5.0.tgz#415c4478f2bcc30120c22ce10ed3226f7d3e18e0"
+  integrity sha1-QVxEePK8wwEgwizhDtMib30+GOA=
 
 lodash.ismatch@^4.4.0:
   version "4.4.0"


### PR DESCRIPTION
Hello! Thanks for such a nice package! I've found one issue on android (iOS works well). I use this library to move user through hints tour and when I change highlightedElementId from one to other on android ClipPath does not changes. I added a key for Svg element so react will clearly understand that it should be rendered.

Also fixed setElements callback in HighlightableElementProvider, now it checks if any parameters were changed before updating the state. 
The source of the problem is HighlightableElement In useEffect. useEffect reacts if the children were changed, but the children change does not actually mean that the measurements of the element were changed. The problem is that setElements was called when children of HighlightableElementProvider were changed even the element's measurements keeps the same, this resulted to rerender of HighlightOverlay because of useHighlightableElements, and this resulted to "blinking" of the dimmed overlay.